### PR TITLE
fix: fixing font_measure and deleting useless type assertions in draw…

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -69,7 +69,7 @@ fn font_measure(
 ) -> Size<f32> {
     let mut paragraph = paragraph::Paragraph::new();
     paragraph.update(Text {
-        content: "A",
+        content: "m",
         font: font_type,
         size: iced_core::Pixels(font_size),
         vertical_alignment: Vertical::Center,


### PR DESCRIPTION
- char that is used for calculating font width and height was changed from `A` to `m` because `m` char has bigger width. It allow rendering more characters.
- useless type assertions inside the `widget.draw` method were removed