### PR TITLE
allow to specify environment variables and working directory in BackendSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ impl App {
         let term_settings = iced_term::settings::Settings {
             backend: iced_term::settings::BackendSettings {
                 shell: system_shell.to_string(),
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -147,6 +147,8 @@ impl Backend {
     ) -> Result<Self> {
         let pty_config = tty::Options {
             shell: Some(tty::Shell::new(settings.program, settings.args)),
+            working_directory: settings.working_directory,
+            env: settings.env,
             ..tty::Options::default()
         };
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, path::PathBuf};
+
 use crate::ColorPalette;
 use iced::Font;
 
@@ -18,6 +20,8 @@ pub struct Settings {
 pub struct BackendSettings {
     pub program: String,
     pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub working_directory: Option<PathBuf>
 }
 
 impl Default for BackendSettings {
@@ -25,6 +29,8 @@ impl Default for BackendSettings {
         Self {
             program: DEFAULT_SHELL.to_string(),
             args: vec![],
+            env: HashMap::new(),
+            working_directory: None
         }
     }
 }


### PR DESCRIPTION
# Personal Motivation
I am currently creating a small app that allows me to create backups from my laptop onto our NAS. For that i am using RSync backup my data. RSync is run inside `iced_term` to show progress information. In order to supply a password to RSync, I have to set the environment variable `RSYNC_PASSWORD` from the app for the rsync-process.

# Descriptions
Allow user to provide a working directory, as well as overrides for environment variables to the `BackendSettings`

# Changes
Add the fields `working_directory` and `env` to the struct `BackendSettings` and forward the provided information to `alacritty_terminal`.

If you consider merging this, I would update the examples and documentation.

