### PR TITLE
chore(dev): use workspace to streamline dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 members = ["examples/*"]
 
+[workspace.dependencies]
+iced = "0.13.1"
+
 [package]
 name = "iced_term"
 description = "Terminal emulator widget powered by ICED framework and alacritty terminal backend."
@@ -13,7 +16,7 @@ license = "MIT"
 
 [dependencies]
 alacritty_terminal = "0.25.0"
-iced = { version = "0.13.1", features = [
+iced = { workspace = true, features = [
     "smol",
     "tokio",
     "canvas",

--- a/examples/custom_bindings/Cargo.toml
+++ b/examples/custom_bindings/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = "0.13.1"
+iced = { workspace = true }
 iced_term = { path = "../../" }

--- a/examples/fonts/Cargo.toml
+++ b/examples/fonts/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = "0.13.1"
+iced = { workspace = true }
 iced_term = { path = "../../" }

--- a/examples/full_screen/Cargo.toml
+++ b/examples/full_screen/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = "0.13.1"
+iced = { workspace = true }
 iced_term = { path = "../../" }

--- a/examples/split_view/Cargo.toml
+++ b/examples/split_view/Cargo.toml
@@ -2,7 +2,8 @@
 name = "split_view"
 version = "0.6.0"
 edition = "2021"
+publish = false
 
 [dependencies]
-iced = { version = "0.13.1" }
+iced = { workspace = true }
 iced_term = { path = "../../" }

--- a/examples/themes/Cargo.toml
+++ b/examples/themes/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = "0.13.1"
+iced = { workspace = true }
 iced_term = { path = "../../" }


### PR DESCRIPTION
This way, the version of `iced` needs only be updated in 1 Cargo.toml.