### PR TITLE
chore(CI): revise CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,19 +1,109 @@
-name: CI
+name: Rust CI
 
 on:
   push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - Cargo.lock
+      - .github/workflows/rust.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - Cargo.lock
+      - .github/workflows/rust.yml
+
+permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  lint:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
-    - name: Lint
-      run: cargo clippy
-    - name: Build
-      run: cargo build --verbose
-    - name: Tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        run: rustup update stable --no-self-update
+      - name: Cache cargo deps
+        uses: actions/cache@v4
+        with:
+          path: |-
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-linting-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run clippy
+        run: cargo clippy --no-deps --all-features -- -D warnings
+      - name: Run rustfmt
+        run: cargo fmt --all --check
+      - name: Pre-publish (dry run)
+        if: runner.os == 'linux'
+        run: cargo publish -p iced_term --dry-run
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        run: rustup update stable --no-self-update
+      - name: Cache cargo deps
+        uses: actions/cache@v4
+        with:
+          path: |-
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-testing-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run tests
+        run: cargo test --all-features --lib --verbose
+  
+  examples:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        example:
+          - custom_bindings
+          - fonts
+          - full_screen
+          - split_view
+          - themes
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        run: rustup update stable --no-self-update
+      - name: Cache cargo deps
+        uses: actions/cache@v4
+        with:
+          path: |-
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-example-${{ matrix.example }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build examples
+        env:
+          EXAMPLE: ${{ matrix.example }}
+        shell: bash
+        run: cargo build -p ${EXAMPLE}
+      - name: Upload example build artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: example-${{ matrix.example }}-${{ matrix.os }}
+          path: target/debug/${{ matrix.example }}${{ runner.os == 'Windows' && '.exe' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Deploy to crates.io
+
+on:
+  push:
+    tags: ['*']
+
+permissions: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      # needed for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Set up Rust
+        run: rustup update stable --no-self-update
+      - name: Establish provenance
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+        id: auth
+      - name: Publish to crates.io
+        run: cargo publish -p iced_term
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This makes the CI workflow more practical.

Includes a release CI workflow that employs [trusted publishing] for crates.io.

You may notice that this is mostly copied from Harzu/egui_term#32 and Harzu/egui_term#36

[trusted publishing]: https://crates.io/docs/trusted-publishing