### PR TITLE
fix: get examples working on Windows

### DIFF
--- a/examples/custom_bindings/src/main.rs
+++ b/examples/custom_bindings/src/main.rs
@@ -37,9 +37,13 @@ struct App {
 
 impl App {
     fn new() -> (Self, Task<Event>) {
+        #[cfg(not(windows))]
         let system_shell = std::env::var("SHELL")
             .expect("SHELL variable is not defined")
             .to_string();
+        #[cfg(windows)]
+        let system_shell = "cmd.exe".to_string();
+
         let term_id = 0;
         let term_settings = iced_term::settings::Settings {
             font: iced_term::settings::FontSettings {

--- a/examples/fonts/src/main.rs
+++ b/examples/fonts/src/main.rs
@@ -40,9 +40,13 @@ struct App {
 
 impl App {
     fn new() -> (Self, Task<Event>) {
+        #[cfg(not(windows))]
         let system_shell = std::env::var("SHELL")
             .expect("SHELL variable is not defined")
             .to_string();
+        #[cfg(windows)]
+        let system_shell = "cmd.exe".to_string();
+
         let term_id = 0;
         let term_settings = iced_term::settings::Settings {
             font: iced_term::settings::FontSettings {

--- a/examples/full_screen/src/main.rs
+++ b/examples/full_screen/src/main.rs
@@ -32,9 +32,13 @@ struct App {
 
 impl App {
     fn new() -> (Self, Task<Event>) {
+        #[cfg(not(windows))]
         let system_shell = std::env::var("SHELL")
             .expect("SHELL variable is not defined")
             .to_string();
+        #[cfg(windows)]
+        let system_shell = "cmd.exe".to_string();
+
         let term_id = 0;
         let term_settings = iced_term::settings::Settings {
             font: iced_term::settings::FontSettings {

--- a/examples/split_view/src/main.rs
+++ b/examples/split_view/src/main.rs
@@ -44,6 +44,13 @@ impl App {
     fn new() -> (Self, Task<Event>) {
         let initial_pane_id = 0;
         let (panes, _) = pane_grid::State::new(Pane::new(initial_pane_id));
+        #[cfg(not(windows))]
+        let system_shell = std::env::var("SHELL")
+            .expect("SHELL variable is not defined")
+            .to_string();
+        #[cfg(windows)]
+        let system_shell = "cmd.exe".to_string();
+
         let term_settings = iced_term::settings::Settings {
             font: iced_term::settings::FontSettings {
                 size: 14.0,
@@ -57,9 +64,7 @@ impl App {
             },
             theme: iced_term::settings::ThemeSettings::default(),
             backend: iced_term::settings::BackendSettings {
-                program: std::env::var("SHELL")
-                    .expect("SHELL variable is not defined")
-                    .to_string(),
+                program: system_shell,
                 ..Default::default()
             },
         };

--- a/examples/themes/src/main.rs
+++ b/examples/themes/src/main.rs
@@ -33,9 +33,13 @@ struct App {
 
 impl App {
     fn new() -> (Self, Task<Event>) {
+        #[cfg(not(windows))]
         let system_shell = std::env::var("SHELL")
             .expect("SHELL variable is not defined")
             .to_string();
+        #[cfg(windows)]
+        let system_shell = "cmd.exe".to_string();
+
         let term_id = 0;
         let term_settings = iced_term::settings::Settings {
             font: iced_term::settings::FontSettings {


### PR DESCRIPTION
This sets the system shell to "cmd.exe" in the examples when built for Windows.