### PR TITLE
chore(CI): fix CI trigger's branch name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,14 +2,14 @@ name: Rust CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
       - Cargo.lock
       - .github/workflows/rust.yml
   pull_request:
-    branches: [main]
+    branches: [master]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"


### PR DESCRIPTION
Oops, I didn't notice that the default branch on this repo was named "master", not "main."

follow-up to #38 