### PR TITLE
Expose BackendCommand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use alacritty_terminal::index::Point as AlacrittyPoint;
 pub use alacritty_terminal::selection::SelectionType;
 pub use alacritty_terminal::term::TermMode;
 pub use backend::Command as BackendCommand;
-pub use backend::{MouseButton, LinkAction};
+pub use backend::{LinkAction, MouseButton};
 pub use terminal::{Command, Event, Terminal};
 pub use theme::{ColorPalette, Theme};
 pub use view::TerminalView;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,11 @@ mod theme;
 mod view;
 
 pub use alacritty_terminal::event::Event as AlacrittyEvent;
+pub use alacritty_terminal::index::Point as AlacrittyPoint;
+pub use alacritty_terminal::selection::SelectionType;
 pub use alacritty_terminal::term::TermMode;
 pub use backend::Command as BackendCommand;
+pub use backend::{MouseButton, LinkAction};
 pub use terminal::{Command, Event, Terminal};
 pub use theme::{ColorPalette, Theme};
 pub use view::TerminalView;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod view;
 
 pub use alacritty_terminal::event::Event as AlacrittyEvent;
 pub use alacritty_terminal::term::TermMode;
+pub use backend::Command as BackendCommand;
 pub use terminal::{Command, Event, Terminal};
 pub use theme::{ColorPalette, Theme};
 pub use view::TerminalView;


### PR DESCRIPTION
Exposes the backend `Command` type at the crate root to allow reference it externally.
I think it will enough to manage commands. According to resolve #61  