### PR TITLE
Fix GUI deadlock: replace blocking_send with try_send

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -580,6 +580,6 @@ pub struct EventProxy(mpsc::Sender<Event>);
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: Event) {
-        let _ = self.0.blocking_send(event);
+        let _ = self.0.try_send(event);
     }
 }


### PR DESCRIPTION
## Problem
The GUI hangs for 20-30 seconds under heavy PTY output. macOS generates spindump reports showing psynch_cvwait (condition variable wait) on the main thread.

## Proposed solution
Switch to the try_send() should no more lead to application crashes.