### PR TITLE
fix: report mouse drags in button-motion (1002) tracking mode

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -226,7 +226,14 @@ impl<'a> TerminalView<'a> {
         // Handle command or selection update based on terminal mode and modifiers
         if state.is_dragged {
             let terminal_mode = terminal_content.terminal_mode;
-            let cmd = if terminal_mode.intersects(TermMode::MOUSE_MOTION) {
+            // Report drags when the app requested button-motion (1002) or
+            // any-motion (1003) tracking. Checking only MOUSE_MOTION left
+            // 1002-mode apps (e.g. tmux with `mouse on`) seeing press and
+            // release but never the drag, while the widget drew its own
+            // selection over the app's — two selection systems at once.
+            let cmd = if terminal_mode
+                .intersects(TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION)
+            {
                 Command::MouseReport(
                     MouseButton::LeftMove,
                     state.keyboard_modifiers,
@@ -989,6 +996,43 @@ mod tests {
             state.is_dragged = true; // Simulate an ongoing drag operation
             let mut terminal_content = RenderableContent::default();
             terminal_content.terminal_mode = TermMode::MOUSE_MOTION;
+            let layout_position = Point { x: 5.0, y: 5.0 };
+            let cursor_position = Point { x: 100.0, y: 150.0 };
+            let mut commands = Vec::new();
+            let _modifiers = Modifiers::empty();
+
+            TerminalView::handle_cursor_moved(
+                &mut state,
+                &terminal_content,
+                &cursor_position,
+                layout_position,
+                &mut commands,
+            );
+
+            assert_eq!(commands.len(), 1);
+            assert!(matches!(
+                commands[0],
+                Command::MouseReport(
+                    MouseButton::LeftMove,
+                    _modifiers,
+                    TerminalGridPoint {
+                        line: Line(49),
+                        column: Column(79),
+                    },
+                    true,
+                )
+            ));
+        }
+
+        #[test]
+        fn reports_drag_when_dragged_in_mouse_drag_mode() {
+            // Button-motion tracking (1002) — what e.g. tmux with `mouse on`
+            // requests — must also report drags, not fall back to the
+            // widget's own selection.
+            let mut state = TerminalViewState::new(0);
+            state.is_dragged = true;
+            let mut terminal_content = RenderableContent::default();
+            terminal_content.terminal_mode = TermMode::MOUSE_DRAG;
             let layout_position = Point { x: 5.0, y: 5.0 };
             let cursor_position = Point { x: 100.0, y: 150.0 };
             let mut commands = Vec::new();


### PR DESCRIPTION
## Problem

`handle_cursor_moved` only reports drag motion to the backend when the terminal is in `MOUSE_MOTION` (1003) mode. Applications that request **button-motion tracking (1002)** — most notably tmux with `set -g mouse on` — get the press and release reports but never the drag in between, while the widget simultaneously runs its own `SelectUpdate` selection.

The result with tmux: tmux sees click+release with no motion (so no copy-mode drag selection), while the widget paints its own selection overlay on top — two selection systems fighting over the same drag.

## Fix

Check `MOUSE_DRAG | MOUSE_MOTION` when deciding whether to report a drag, matching how press/release already use the umbrella `MOUSE_MODE` (which includes all three tracking modes). Widget-side selection still applies when neither motion mode is active (plain 1000 click-only tracking).

Includes a regression test (`reports_drag_when_dragged_in_mouse_drag_mode`).

## Repro

1. run an app embedding the widget and attach to `tmux -L test` with `set -g mouse on`
2. drag-select some text in a pane
3. before: widget-local selection appears and tmux never enters copy-mode; double-click flashes tmux word-select while the widget selects independently
4. after: drags are reported and tmux handles selection natively, as in other terminals