### PR TITLE
fix: glyph under the block cursor invisible on INVERSE/selected cells

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -480,6 +480,10 @@ impl Widget<Event, Theme, iced::Renderer> for TerminalView<'_> {
                 // Resolve colors for this cell
                 let mut fg = self.term.theme.get_color(indexed.fg);
                 let mut bg = self.term.theme.get_color(indexed.bg);
+                // Pre-swap background: the block cursor is painted in the
+                // cell's (pre-swap) fg, so this is the contrasting color
+                // for the glyph under it regardless of INVERSE/selection.
+                let cell_bg = bg;
 
                 // If the new line was detected,
                 // need to flush pending background rect and init the new one
@@ -581,10 +585,16 @@ impl Widget<Event, Theme, iced::Renderer> for TerminalView<'_> {
 
                 // Draw text
                 if indexed.c != ' ' && indexed.c != '\t' {
+                    // The glyph under the block cursor must contrast with
+                    // the cursor rect (painted above in the cell's pre-swap
+                    // fg). Using the post-swap bg — or gating this on
+                    // APP_CURSOR, a keypad mode unrelated to rendering —
+                    // made the glyph invisible whenever the cell was
+                    // INVERSE or inside a selection.
                     if content.grid.cursor.point == indexed.point
-                        && content.terminal_mode.contains(TermMode::APP_CURSOR)
+                        && content.terminal_mode.contains(TermMode::SHOW_CURSOR)
                     {
-                        fg = bg;
+                        fg = cell_bg;
                     }
                     // Resolve font style (bold/italic) from cell flags
                     let mut font = self.term.font.font_type;


### PR DESCRIPTION
## Problem

The block cursor rect is painted in the cell's pre-swap fg color, but the glyph on top of it is recolored to the **post-swap** bg — and only when `APP_CURSOR` is set, a keypad/cursor-keys mode that has nothing to do with rendering.

On a cell with the `INVERSE` flag or inside a selection, the fg/bg swap has already happened by then, so glyph and cursor rect end up the same color: the character under the cursor disappears. Easy to hit in practice:

- nvim: the character under the cursor vanishes (nvim renders its cursor cell inverse)
- selecting across the shell prompt: the letter under the block cursor blinks out

Minimal repro in a plain shell:

```sh
printf 'X\e[7mY\e[27mZ\e[2D'; sleep 5   # cursor ends on the inverse Y
```

Before: `X▮Z` — the Y is invisible inside the cursor block. After: `XYZ` with the Y readable inside the block.

## Fix

Capture the cell's **pre-swap** bg and use it for the glyph whenever the cursor is shown on that cell (`SHOW_CURSOR`), unconditionally — the cursor rect is painted in the pre-swap fg, so the pre-swap bg is the contrasting color regardless of INVERSE/selection. Also drops the unrelated `APP_CURSOR` gate: without it, the glyph under the cursor was invisible in the (common) non-application-mode case too, whenever cell fg ≈ cursor color.